### PR TITLE
[codex] Fix heading capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 
 ## After the latest release / Nach dem letzten Release
 
+- Fixed inconsistent capitalization in partner h5 headings.
 - Updated Slovak translations; thanks to Ladislav Rosival.
 
 ## Previous releases

--- a/resources/views/partials/family-part-renderers/grouped-headings/partners.phtml
+++ b/resources/views/partials/family-part-renderers/grouped-headings/partners.phtml
@@ -14,9 +14,10 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\ExtendedFamilySupport;
 
                         <?php $family = $entry->family ?>
                         <?php $partnerStatus = ExtendedFamilySupport::translateFamilyStatusAsPartner($entry->familyStatus ?: ExtendedFamilySupport::FAM_STATUS_PARTNERSHIP) ?>
+                        <?php $partnerStatusHeading = ExtendedFamilySupport::headingLabel($partnerStatus) ?>
                         <?php $partnerStatusLabel = $group->partner->xref() == $extfam_obj->proband->indi->xref()
-                            ? $partnerStatus
-                            : I18N::translate('%1$s of %2$s', $partnerStatus, ExtendedFamilySupport::individualLink($group->partner)) ?>
+                            ? $partnerStatusHeading
+                            : I18N::translate('%1$s of %2$s', $partnerStatusHeading, ExtendedFamilySupport::individualLink($group->partner)) ?>
                         <?php if ($family instanceof Family): ?>
                             <?php if ($family->canShow()): ?>
                                 <h5><?= $partnerStatusLabel ?>&nbsp;<a href="<?= e($family->url()) ?>"><?= $family->fullName() ?></a></h5>

--- a/src/Factory/Objects/ExtendedFamilySupport.php
+++ b/src/Factory/Objects/ExtendedFamilySupport.php
@@ -41,6 +41,7 @@ use function strtolower;
 use function str_contains;  // will be added in PHP 8.0, at the moment part of the framework
 use function trim;
 use function preg_match;
+use function mb_substr;
 
 // array functions
 use function in_array;
@@ -655,6 +656,23 @@ class ExtendedFamilySupport
             self::FAM_STATUS_PARTNERSHIP => I18N::translate('partner'),
             default                      => I18N::translate($familyStatus),
         };
+    }
+
+    /**
+     * Capitalize translated labels when they start a heading.
+     *
+     * @param string $label
+     * @return string
+     */
+    public static function headingLabel(string $label): string
+    {
+        $label = trim($label);
+
+        if ($label === '') {
+            return '';
+        }
+
+        return I18N::strtoupper(mb_substr($label, 0, 1)) . mb_substr($label, 1);
     }
 
     /**


### PR DESCRIPTION
## Summary

- capitalize translated partner-status labels when they start an h5 heading
- keep the lower-case status labels unchanged for inline label/badge use
- add the fix to the unreleased change log

## Root cause

`translateFamilyStatusAsPartner()` intentionally returns lower-case labels such as `married partner` for inline use. The partner renderer also used the same text at the start of h5 headings, which made those headings start with a lower-case word.

Closes #238.

## Validation

- `php -l src/Factory/Objects/ExtendedFamilySupport.php`
- `php -l resources/views/partials/family-part-renderers/grouped-headings/partners.phtml`
- `git diff --check`