### PR TITLE
[codex] Filter associated person seed records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 
 ## After the latest release / Nach dem letzten Release
 
+- Limited godparent/witness lookup to displayed extended-family people and their own partnership families.
 - Updated Slovak translations; thanks to Ladislav Rosival.
 
 ## Previous releases

--- a/src/Factory/ExtendedFamilyParts/Godparents_witnesses.php
+++ b/src/Factory/ExtendedFamilyParts/Godparents_witnesses.php
@@ -92,7 +92,7 @@ class Godparents_witnesses extends ExtendedFamilyPart
     private function seedRecords(): array
     {
         $individuals = [$this->getProband()->xref() => $this->getProband()];
-        $families = [];
+        $candidateFamilies = [];
 
         foreach ($this->seedFamilyParts as $propName => $familyPart) {
             if ($propName === 'summary') {
@@ -108,7 +108,7 @@ class Godparents_witnesses extends ExtendedFamilyPart
 
                 foreach ($familyPart->collectionFamilies ?? [] as $family) {
                     if ($family instanceof Family) {
-                        $families[$family->xref()] = $family;
+                        $candidateFamilies[$family->xref()] = $family;
                     }
                 }
 
@@ -117,7 +117,7 @@ class Godparents_witnesses extends ExtendedFamilyPart
 
             foreach ($familyPart->groups ?? [] as $group) {
                 if (($group->family ?? null) instanceof Family) {
-                    $families[$group->family->xref()] = $group->family;
+                    $candidateFamilies[$group->family->xref()] = $group->family;
                 }
 
                 foreach ($group->entries ?? [] as $entry) {
@@ -126,29 +126,34 @@ class Godparents_witnesses extends ExtendedFamilyPart
                     }
 
                     if (($entry->family ?? null) instanceof Family) {
-                        $families[$entry->family->xref()] = $entry->family;
-                    }
-
-                    foreach ($entry->referencePersons ?? [] as $referencePerson) {
-                        if ($referencePerson instanceof Individual) {
-                            $individuals[$referencePerson->xref()] = $referencePerson;
-                        }
+                        $candidateFamilies[$entry->family->xref()] = $entry->family;
                     }
                 }
             }
         }
 
-        foreach ($individuals as $individual) {
-            foreach ($individual->spouseFamilies() as $family) {
-                $families[$family->xref()] = $family;
-            }
-
-            foreach ($individual->childFamilies() as $family) {
+        $families = [];
+        foreach ($candidateFamilies as $family) {
+            if ($this->familyHasSeedSpouse($family, $individuals)) {
                 $families[$family->xref()] = $family;
             }
         }
 
         return [...array_values($individuals), ...array_values($families)];
+    }
+
+    /**
+     * @param array<string,Individual> $individuals
+     */
+    private function familyHasSeedSpouse(Family $family, array $individuals): bool
+    {
+        foreach ($family->spouses() as $spouse) {
+            if ($spouse instanceof Individual && array_key_exists($spouse->xref(), $individuals)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

- restrict the records scanned by the godparents/witnesses family part
- use displayed extended-family people as seed individuals, but no longer add pure reference persons automatically
- keep only candidate family records where at least one spouse belongs to the seed individuals
- add the fix to the unreleased change log

## Root cause

The godparents/witnesses lookup used every reference person from the other family parts and then added all spouse and child families of all collected individuals. That made helper records part of the scan. In particular, parent families that were only needed to determine in-law or co-in-law relationships could contribute their marriage witnesses, although those parents themselves are not part of the extended family.

With this change, families are scanned only when they are candidate families from the rendered family parts and at least one spouse/partner belongs to the displayed extended-family seed persons.

Closes #237.

## Validation

- `php -l src/Factory/ExtendedFamilyParts/Godparents_witnesses.php`
- `git diff --check`