### PR TITLE
[codex] Include proband in oldest person statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 
 ## After the latest release / Nach dem letzten Release
 
+- Included the proband when calculating oldest direct-line people.
 - Updated Slovak translations; thanks to Ladislav Rosival.
 
 ## Previous releases

--- a/ExtendedFamily.php
+++ b/ExtendedFamily.php
@@ -559,10 +559,6 @@ class ExtendedFamily
     {
         $individuals = [];
         foreach ($rows as $row) {
-            if ($row->generation === 1) {
-                continue;
-            }
-
             foreach ($row->individuals as $individual) {
                 $individuals[$individual->xref()] = $individual;
             }
@@ -603,10 +599,6 @@ class ExtendedFamily
             foreach ($rows as $row) {
                 if ($row->generationLength !== null) {
                     $generationLengths[] = $row->generationLength;
-                }
-
-                if ($row->generation === 1) {
-                    continue;
                 }
 
                 foreach ($row->individuals as $individual) {


### PR DESCRIPTION
## Summary

- include the proband in direct-line summary person sets
- make oldest-person calculations consider the self row as part of the extended family summary
- add the fix to the unreleased change log

## Root cause

The direct-line rows already contain the proband as generation 1, and the table displays that row. However, `lineageSummary()` and `combinedLineageSummary()` skipped generation 1 when collecting individuals for average lifespan and oldest-person calculations. This could make the summary report the second-oldest person when the proband was actually the oldest.

Generation lengths are still calculated only from rows with actual generation gaps.

Closes #239.

## Validation

- `php -l ExtendedFamily.php`
- `git diff --check`