### PR TITLE
[codex] Respect hidden individual names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 ## After the latest release / Nach dem letzten Release
 
 - Updated Slovak translations; thanks to Ladislav Rosival.
+- Respect hidden individual names when rendering partner lists and partner chains.
 
 ## Previous releases
 

--- a/resources/views/partials/family-part-renderers/godparents-witnesses.phtml
+++ b/resources/views/partials/family-part-renderers/godparents-witnesses.phtml
@@ -32,12 +32,8 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\ExtendedFamilySupport;
                             <tr>
                                 <td>
                                     <?php if ($entry->associatedIndividual instanceof Individual): ?>
-                                        <?php if ($entry->associatedIndividual->canShow()): ?>
-                                            <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($entry->associatedIndividual, $extfam_obj->proband->indi) : '' ?>
-                                            <a href="<?= e($entry->associatedIndividual->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $entry->associatedIndividual->fullName() ?></a>
-                                        <?php else: ?>
-                                            <?= $entry->associatedIndividual->fullName() ?>
-                                        <?php endif ?>
+                                        <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($entry->associatedIndividual, $extfam_obj->proband->indi) : '' ?>
+                                        <?= ExtendedFamilySupport::individualLink($entry->associatedIndividual, $relationshipName) ?>
                                     <?php else: ?>
                                         <?= e($entry->associatedName) ?>
                                     <?php endif ?>

--- a/resources/views/partials/family-part-renderers/grouped.phtml
+++ b/resources/views/partials/family-part-renderers/grouped.phtml
@@ -43,7 +43,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\Nephews_and_nieces;
                             <?php endif ?>
                             <span class="hh_extended_family_counter"><?= $i ?></span>
                             <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($indi, $extfam_obj->proband->indi) : '' ?>
-                            <span class="hh_extended_family_name"><a href="<?= e($indi->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $indi->fullName() ?></a></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualLink($indi, $relationshipName) ?></span>
                             <?php if ($extfam_obj->config->useCompactDesign): ?>
                                 <span class="hh_extended_family_lifespan" ><?= $indi->lifespan() ?></span>
                             <?php else: ?>
@@ -66,7 +66,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\Nephews_and_nieces;
                             <?php if ($propName == 'children_in_law'): ?>
                                 <span class="hh_extended_family_label_box"><?= ExtendedFamilySupport::translateFamilyStatusAsPartner($entry->familyStatus) ?></span>&nbsp;
                             <?php endif ?>
-                            <span class="hh_extended_family_name"><?= $indi->fullName() ?></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualName($indi) ?></span>
                         <?php endif ?>
                     </div>
                 <?php $i++; endforeach ?>

--- a/resources/views/partials/family-part-renderers/parents-in-law.phtml
+++ b/resources/views/partials/family-part-renderers/parents-in-law.phtml
@@ -18,12 +18,8 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\Nephews_and_nieces;
         <?php foreach ($filterObj->efp->$propName->groups as $group): ?>
             <div class="hh_extended_family_box">
                 <h4>
-                    <?php if ($group->partner->canShow()): ?>
-                        <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($group->partner, $extfam_obj->proband->indi) : '' ?>
-                        <span class="hh_extended_family_name"><?= I18N::translate($group->partnerFamilyStatus) ?> <?= I18N::translate('with') ?> <a href="<?= e($group->partner->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $group->partner->fullName() ?></a></span>
-                    <?php else: ?>
-                        <span class="hh_extended_family_name"><?= I18N::translate('Partnership') . ' ' . I18N::translate('with') . ' ' . $group->partner->fullName() ?></span>
-                    <?php endif ?>
+                    <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($group->partner, $extfam_obj->proband->indi) : '' ?>
+                    <span class="hh_extended_family_name"><?= I18N::translate($group->partnerFamilyStatus) ?> <?= I18N::translate('with') ?> <?= ExtendedFamilySupport::individualLink($group->partner, $relationshipName) ?></span>
                     &nbsp;(<?= count($group->entries) ?>)
                 </h4>
                 <?php $prev_fam_id = '-1'; ?>
@@ -44,7 +40,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\Nephews_and_nieces;
                             <?php endif ?>
                             <span class="hh_extended_family_counter"><?= $i ?></span>
                             <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($indi, $extfam_obj->proband->indi) : '' ?>
-                            <span class="hh_extended_family_name"><a href="<?= e($indi->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $indi->fullName() ?></a></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualLink($indi, $relationshipName) ?></span>
                             <?php if ($extfam_obj->config->useCompactDesign): ?>
                                 <span class="hh_extended_family_lifespan" ><?= $indi->lifespan() ?></span>
                             <?php else: ?>
@@ -53,7 +49,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\Nephews_and_nieces;
                                 </span>
                             <?php endif ?>
                         <?php else: ?>
-                            <span class="hh_extended_family_name"><?= $indi->fullName() ?></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualName($indi) ?></span>
                         <?php endif ?>
                     </div>
                 <?php $i++; endforeach ?>

--- a/resources/views/partials/family-part-renderers/partners.phtml
+++ b/resources/views/partials/family-part-renderers/partners.phtml
@@ -17,12 +17,8 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\ExtendedFamilySupport;
                     <?php if ($group->partner->xref() == $extfam_obj->proband->indi->xref()): ?>
                         <?= $extfam_obj->proband->niceName->plain ?>
                     <?php else: ?>
-                        <?php if ($group->partner->canShow()): ?>
-                            <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($group->partner, $extfam_obj->proband->indi) : '' ?>
-                            <span class="hh_extended_family_name"><a href="<?= e($group->partner->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $group->partner->fullName() ?></a></span>
-                        <?php else: ?>
-                            <span class="hh_extended_family_name"><?= $group->partner->fullName() ?></span>
-                        <?php endif ?>
+                        <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($group->partner, $extfam_obj->proband->indi) : '' ?>
+                        <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualLink($group->partner, $relationshipName) ?></span>
                     <?php endif ?>
                     &nbsp;(<?= count($group->entries) ?>)
                 </h4>
@@ -37,7 +33,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\ExtendedFamilySupport;
                             <?php endif ?>
                             <span class="hh_extended_family_counter"><?= $i ?></span>
                             <?php $relationshipName = $extfam_obj->config->showRelationshipToProband ? ExtendedFamilySupport::relationshipNameToProband($indi, $extfam_obj->proband->indi) : '' ?>
-                            <span class="hh_extended_family_name"><a href="<?= e($indi->url()) ?>"<?= $relationshipName !== '' ? ' title="' . e($relationshipName) . '"' : '' ?>><?= $indi->fullName() ?></a></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualLink($indi, $relationshipName) ?></span>
                             <?php if ($extfam_obj->config->showLabels && $entry->labels): ?>
                                 <?php foreach ($entry->labels as $label): ?>
                                     <span class="hh_extended_family_label_box"><?= $label ?></span>&nbsp;
@@ -56,7 +52,7 @@ use Hartenthaler\Webtrees\Module\ExtendedFamily\ExtendedFamilySupport;
                                 </span>
                             <?php endif ?>
                         <?php else: ?>
-                            <span class="hh_extended_family_name"><?= $indi->fullName() ?></span>
+                            <span class="hh_extended_family_name"><?= ExtendedFamilySupport::individualName($indi) ?></span>
                         <?php endif ?>
                     </div>
                 <?php $i++; endforeach ?>

--- a/src/Factory/ExtendedFamilyParts/Partner_chains.php
+++ b/src/Factory/ExtendedFamilyParts/Partner_chains.php
@@ -348,8 +348,8 @@ class Partner_chains extends ExtendedFamilyPart
         if ($node->getIndividual() instanceof Individual) {
             $chainString .= strval($i) . '§';
             if ($node->getFilterComment() == '') {
-                $chainString .= (($node->getIndividual()->canShow()) ? '1' : '0') .
-                                '§' . $node->getIndividual()->fullName() .
+                $chainString .= (ExtendedFamilySupport::canLinkIndividual($node->getIndividual()) ? '1' : '0') .
+                                '§' . ExtendedFamilySupport::individualName($node->getIndividual()) .
                                 '§' . $node->getIndividual()->url();
             } else {
                 $chainString .= I18N::translate($node->getFilterComment());

--- a/src/Factory/Objects/ExtendedFamilySupport.php
+++ b/src/Factory/Objects/ExtendedFamilySupport.php
@@ -23,6 +23,7 @@
 
 namespace Hartenthaler\Webtrees\Module\ExtendedFamily;
 
+use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Elements\PedigreeLinkageType;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
@@ -93,13 +94,42 @@ class ExtendedFamilySupport
         ];
     }
 
-    public static function individualLink(Individual $person): string
+    public static function individualName(Individual $person): string
     {
-        if ($person->canShow()) {
-            return '<a href="' . e($person->url()) . '">' . $person->fullName() . '</a>';
+        if (!$person->canShow() || !self::hasVisibleNameFacts($person)) {
+            return I18N::translate('Private');
         }
 
         return $person->fullName();
+    }
+
+    public static function individualLink(Individual $person, string $title = ''): string
+    {
+        $name = self::individualName($person);
+
+        if (self::canLinkIndividual($person)) {
+            $titleAttribute = $title === '' ? '' : ' title="' . e($title) . '"';
+
+            return '<a href="' . e($person->url()) . '"' . $titleAttribute . '>' . $name . '</a>';
+        }
+
+        return $name;
+    }
+
+    public static function canLinkIndividual(Individual $person): bool
+    {
+        return $person->canShow() && self::hasVisibleNameFacts($person);
+    }
+
+    private static function hasVisibleNameFacts(Individual $person): bool
+    {
+        $allNameFacts = $person->facts(['NAME'], false, Auth::PRIV_HIDE);
+
+        if ($allNameFacts->isEmpty()) {
+            return true;
+        }
+
+        return $person->facts(['NAME'])->count() === $allNameFacts->count();
     }
 
     public static function partnerInFamilyLink(Family $family, Individual $person): string


### PR DESCRIPTION
## What changed

- Added shared helpers for privacy-aware individual names and links.
- Updated partner lists, partner chains, generic grouped family-part rows, parents-in-law rows, and godparent/witness rows to use the shared helpers.
- Partner chains no longer serialize the raw full name before deciding whether the person/name may be shown.

## Why

Issue #241 reports that a partner name marked as hidden still appears in the family list. The affected renderers built links and fallback spans directly from `fullName()`, so hidden NAME facts could still be exposed in module output.

Closes #241.

## Validation

- `php -l src/Factory/Objects/ExtendedFamilySupport.php`
- `php -l src/Factory/ExtendedFamilyParts/Partner_chains.php`
- `php -l resources/views/partials/family-part-renderers/partners.phtml`
- `php -l resources/views/partials/family-part-renderers/grouped.phtml`
- `php -l resources/views/partials/family-part-renderers/parents-in-law.phtml`
- `php -l resources/views/partials/family-part-renderers/godparents-witnesses.phtml`
- `git diff --check`