### PR TITLE
Handle collection spouse lists in role loop detection

### DIFF
--- a/ExtendedFamily.php
+++ b/ExtendedFamily.php
@@ -336,10 +336,13 @@ class ExtendedFamily
      */
     private function addFamilyRoleLoopFamilyEdges(Family $family, array $individuals, array &$edges, array &$adjacency, array &$spouseEdges): void
     {
-        $spouses = array_values(array_filter(
-            $family->spouses(),
-            static fn (Individual $individual): bool => isset($individuals[$individual->xref()])
-        ));
+        $spouses = $family->spouses();
+        $spouses = $spouses instanceof Collection
+            ? $spouses->filter(static fn (Individual $individual): bool => isset($individuals[$individual->xref()]))->values()->all()
+            : array_values(array_filter(
+                $spouses,
+                static fn (Individual $individual): bool => isset($individuals[$individual->xref()])
+            ));
 
         for ($left = 0; $left < count($spouses); $left++) {
             for ($right = $left + 1; $right < count($spouses); $right++) {


### PR DESCRIPTION
Fixes a runtime error introduced with the family-role loop detection when webtrees returns spouse lists as Illuminate collections instead of arrays.\n\nChecks:\n- php -l ExtendedFamily.php\n- git diff --check