### PR TITLE
Ignore non-positive generation lengths in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 - Updated Czech translations; thanks to Josef Prause.
 - Disabled unsafe translated strings with mismatched placeholders to avoid runtime errors.
 - Detect family-role loops in the displayed extended family and show them as compact node chains in the summary.
+- Ignore non-positive generation lengths when calculating average generation length for the summary.
 
 ## 2.2.6.10 - 2026-06-29
 

--- a/ExtendedFamily.php
+++ b/ExtendedFamily.php
@@ -905,7 +905,10 @@ class ExtendedFamily
             }
         }
 
-        $generationLengths = array_values(array_filter(array_map(static fn (LineageRow $row): ?int => $row->generationLength, $rows), static fn (?int $length): bool => $length !== null));
+        $generationLengths = array_values(array_filter(
+            array_map(static fn (LineageRow $row): ?int => $row->generationLength, $rows),
+            static fn (?int $length): bool => $length !== null && $length > 0
+        ));
         $lifespans = [];
 
         foreach ($individuals as $individual) {
@@ -938,7 +941,7 @@ class ExtendedFamily
 
         foreach ([$ancestorRows, $descendantRows] as $rows) {
             foreach ($rows as $row) {
-                if ($row->generationLength !== null) {
+                if ($row->generationLength !== null && $row->generationLength > 0) {
                     $generationLengths[] = $row->generationLength;
                 }
 

--- a/resources/views/partials/summary.phtml
+++ b/resources/views/partials/summary.phtml
@@ -147,6 +147,19 @@ if ($familyRoleLoops?->hasAny()) {
     );
 }
 
+if ($extfam_obj->config->showSummaryStatistics && $statistics !== null) {
+    $implex = $lineageStatistics?->implex ?? null;
+    if ($implex?->hasAncestors) {
+        $summarySentences[] = I18N::translate('Ancestor implex: %s.', $formatImplexPeople($implex->ancestors));
+    }
+    if ($implex?->hasDescendants) {
+        $summarySentences[] = I18N::translate('Descendant implex: %s.', $formatImplexPeople($implex->descendants));
+    }
+    if ($implex !== null && !$implex->hasAny) {
+        $summarySentences[] = I18N::translate('No ancestor or descendant implex was detected in the selected direct-line generations.');
+    }
+}
+
 if ($coveredGenerationCount !== null) {
     $summarySentences[] = I18N::translate(
         'The selected direct line covers %s.',
@@ -206,17 +219,6 @@ if ($extfam_obj->config->showSummaryStatistics && $statistics !== null) {
         if ($combinedLineage->oldestFemale !== null) {
             $summarySentences[] = I18N::translate('Oldest female person: %s.', $formatOldest($combinedLineage->oldestFemale));
         }
-    }
-
-    $implex = $lineageStatistics?->implex ?? null;
-    if ($implex?->hasAncestors) {
-        $summarySentences[] = I18N::translate('Ancestor implex: %s.', $formatImplexPeople($implex->ancestors));
-    }
-    if ($implex?->hasDescendants) {
-        $summarySentences[] = I18N::translate('Descendant implex: %s.', $formatImplexPeople($implex->descendants));
-    }
-    if ($implex !== null && !$implex->hasAny) {
-        $summarySentences[] = I18N::translate('No ancestor or descendant implex was detected in the selected direct-line generations.');
     }
 }
 


### PR DESCRIPTION
This PR adjusts the direct-line summary for complex role-loop examples.\n\nChanges:\n- keep negative generation-length values in the detailed generation table, where they explain the special constellation\n- exclude non-positive generation lengths from average generation-length calculations\n- move the implex sentence directly after the family-role-loop sentence\n- update the changelog\n\nChecks:\n- php -l ExtendedFamily.php\n- php -l resources/views/partials/summary.phtml\n- git diff --check