### PR TITLE
Use end dates for strict step-parent logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 - Ignore non-positive generation lengths when calculating average generation length for the summary.
 - Show branched partner chains when the proband has multiple direct partners.
 - Add a strict/sequential step-parent concept as the default, with the previous relaxed/symmetrical interpretation still available as an option.
+- In strict step-parent mode, use divorce/annulment and partner death dates to identify partner families that ended before a later child was born.
 
 ## 2.2.6.10 - 2026-06-29
 

--- a/src/Factory/ExtendedFamilyPart.php
+++ b/src/Factory/ExtendedFamilyPart.php
@@ -296,9 +296,9 @@ abstract class ExtendedFamilyPart
     /**
      * Check whether a parent's partner should be treated as a stepparent.
      *
-     * The strict concept excludes clearly earlier partner families for children
-     * born in a later partnership. If chronology is unknown, the existing
-     * relaxed result is retained.
+     * The strict concept excludes earlier partner families only if they were
+     * clearly ended before the child was born. If chronology is unknown, the
+     * existing relaxed result is retained.
      *
      * @param Individual $child
      * @param IndividualFamily $stepparent
@@ -310,36 +310,53 @@ abstract class ExtendedFamilyPart
             return true;
         }
 
+        $family = $stepparent->getFamily();
         $birthDate = $child->getBirthDate();
-        $familyDate = $this->earliestFamilyRelationDate($stepparent->getFamily());
 
-        if (!$birthDate->isOK() || !$familyDate instanceof Date || !$familyDate->isOK()) {
+        if (!$family instanceof Family || !$birthDate->isOK()) {
             return true;
         }
 
-        return $familyDate->julianDay() >= $birthDate->julianDay();
+        $endDate = $this->partnerFamilyEndDate($family);
+
+        if (!$endDate instanceof Date || !$endDate->isOK()) {
+            return true;
+        }
+
+        return Date::compare($endDate, $birthDate) >= 0;
     }
 
     /**
-     * Return the earliest known event date of a partner family.
+     * Return the earliest known end date of a partner family.
      *
      * @param Family $family
      * @return Date|null
      */
-    private function earliestFamilyRelationDate(Family $family): ?Date
+    private function partnerFamilyEndDate(Family $family): ?Date
     {
-        $earliestDate = null;
-        foreach ($family->facts(['ANUL', 'DIV', 'ENGA', 'EVEN', 'MARB', 'MARC', 'MARL', 'MARR', 'MARS'], true) as $fact) {
+        $endDate = null;
+        foreach ($family->facts(['ANUL', 'DIV'], true) as $fact) {
             if (!$fact instanceof Fact || !$fact->date()->isOK()) {
                 continue;
             }
 
-            if (!$earliestDate instanceof Date || $fact->date()->julianDay() < $earliestDate->julianDay()) {
-                $earliestDate = $fact->date();
+            if (!$endDate instanceof Date || Date::compare($fact->date(), $endDate) < 0) {
+                $endDate = $fact->date();
             }
         }
 
-        return $earliestDate;
+        foreach ($family->spouses() as $spouse) {
+            $deathDate = $spouse->getDeathDate();
+            if (!$deathDate->isOK()) {
+                continue;
+            }
+
+            if (!$endDate instanceof Date || Date::compare($deathDate, $endDate) < 0) {
+                $endDate = $deathDate;
+            }
+        }
+
+        return $endDate;
     }
 
     /**


### PR DESCRIPTION
Follow-up for #254.\n\nThe first strict step-parent implementation compared the child's birth date with the earliest known family/relationship event of the parent's other partner family. That was too broad. For the strict/sequential concept the relevant question is whether the other partner family had already ended before the child was born.\n\nThis PR changes the strict check to use relationship end dates:\n- DIV and ANUL family facts\n- death dates of either partner in that family\n\nIf the end date is known and before the child's birth, the partner is not treated as a stepparent. If the chronology is incomplete, the previous relaxed result is retained.\n\nValidation:\n- php -l src/Factory/ExtendedFamilyPart.php\n- git diff --check