### PR TITLE
Remove living percentages from summary table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ It should be reviewed and converted into meaningful GitHub release notes before 
 
 ## After the latest release / Nach dem letzten Release
 
+- Removed living/deceased percentages from the direct-line summary table.
+
 ## 2.2.6.12 - 2026-07-09
 
 - Added configurable columns for the direct-line summary table, including a combined living/deceased column.

--- a/resources/views/partials/summary.phtml
+++ b/resources/views/partials/summary.phtml
@@ -54,13 +54,7 @@ $formatLivingDeceased = static function ($row): string {
         return '-';
     }
 
-    return I18N::translate(
-        '%1$s (%2$s) / %3$s (%4$s)',
-        I18N::number($row->livingCount),
-        I18N::percentage($row->livingCount / $row->totalCount),
-        I18N::number($row->deceasedCount),
-        I18N::percentage($row->deceasedCount / $row->totalCount)
-    );
+    return I18N::number($row->livingCount) . ' / ' . I18N::number($row->deceasedCount);
 };
 $formatOldest = static function (?object $oldest): string {
     if ($oldest === null) {


### PR DESCRIPTION
## Summary
- show living and deceased counts without percentages in the direct-line summary table
- keep the percentages in the descriptive summary text unchanged

Closes #278

## Validation
- Test-WebtreesModule.ps1
- PHP syntax checks
- git diff --check